### PR TITLE
fix(jobs): fix job instancing issue

### DIFF
--- a/src/Exceptions/MissingMainCharacterException.php
+++ b/src/Exceptions/MissingMainCharacterException.php
@@ -1,0 +1,19 @@
+<?php
+
+
+namespace Herpaderpaldent\Seat\SeatGroups\Jobs;
+
+
+use Exception;
+use Seat\Web\Models\Group;
+
+class MissingMainCharacterException extends Exception
+{
+    public function __construct(Group $group)
+    {
+        $message = sprintf('The group with ID %d does not have a main character set, ' .
+            'or related character information is missing.', $group->id);
+
+        parent::__construct($message, 0, null);
+    }
+}


### PR DESCRIPTION
Sometimes, a group may not have a character set or data related to the character may be removed
from the database due to expired token or other things.

With the current way, when jobs are instancing, it may throw an exception.
Since no try/catch has been put on the dispatcher, it will crash and stop queuing further jobs.

This commit is avoiding exception on the GroupSync job constructor and if no main has been set, attempt to continue the process using the first character attached to the group. Also, in order to avoid strange pattern, funnel is based on group ID instead main_character.