### PR TITLE
Version 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# Version 1.5.0
+Another major update on seat-groups. Containing many demanded features such as:
+* Dispatching update job via web interface.
+* Seat-Groups jobs are now dispatched on `high` queue (thanks @mmolitor87 for the suggestion).
+* Clicking multiple times on `Add new SeAT Group` does not append multiple sets of roles anymore (thank you @MoucceuWildfire for reporting).
+* SeAT-Groups now only logs attached and detached role events instead of every successful run (thank you @warlof for the idea).
+* Deactivated users don't raise `MissingRefreshTokenExceptions` anymore
+* `MissingRefreshTokenExceptions` are now more verbose.
+
+As you can see many of the implemented features are based from your valuable input. Please don't hesitate to contact me IG or via [slack](https://eveseat-slack.herokuapp.com/) (join plugin channel) with anything you'd like to discuss.
+
 # Version 1.4.2
 * Fixxed a bug causing to show all hidden-groups, instead of only the hidden-groups where a user is a member of. Thank you @jediefe for reporting this.
 * Removed raw:db statements from migrations (preparation for testing).

--- a/src/Commands/SeatGroupsUsersUpdate.php
+++ b/src/Commands/SeatGroupsUsersUpdate.php
@@ -38,13 +38,13 @@ class SeatGroupsUsersUpdate extends Command
                     return $users_group->main_character_id != '0';
                 })
                 ->each(function ($group) {
-                    dispatch(new GroupSync($group));
+                    dispatch(new GroupSync($group))->onQueue('high');
                     $this->info(sprintf('A synchronization job has been queued in order to update %s (%s) roles.', $group->main_character->name,
                         $group->users->map(function ($user) { return $user->name; })->implode(', ')));
             });
 
         } else {
-            GroupDispatcher::dispatch();
+            GroupDispatcher::dispatch()->onQueue('high');
             $this->info('A synchronization job has been queued in order to update all SeAT Group roles.');
         }
 

--- a/src/Exceptions/MissingRefreshTokenException.php
+++ b/src/Exceptions/MissingRefreshTokenException.php
@@ -20,5 +20,4 @@ class MissingRefreshTokenException extends Exception
 
         parent::__construct($message, 0, null);
     }
-
 }

--- a/src/Exceptions/MissingRefreshTokenException.php
+++ b/src/Exceptions/MissingRefreshTokenException.php
@@ -9,8 +9,16 @@
 namespace Herpaderpaldent\Seat\SeatGroups\Exceptions;
 
 use Exception;
+use Seat\Web\Models\User;
 
 class MissingRefreshTokenException extends Exception
 {
+    public function __construct(User $user)
+    {
+        $message = sprintf('The user group with ID %d is missing a refresh_token from %s (%d) ' .
+            'therefore the user group loses all its roles and permissions. To fix this: ask the user to login to SeAT again.', $user->group_id, $user->name, $user->id);
+
+        parent::__construct($message, 0, null);
+    }
 
 }

--- a/src/Http/Controllers/SeatGroupsController.php
+++ b/src/Http/Controllers/SeatGroupsController.php
@@ -11,6 +11,7 @@ use Herpaderpaldent\Seat\SeatGroups\Http\Validation\CreateSeatGroupRequest;
 use Herpaderpaldent\Seat\SeatGroups\Http\Validation\DeleteSeatGroupRequest;
 use Herpaderpaldent\Seat\SeatGroups\Models\Seatgroup;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Artisan;
 use Seat\Services\Repositories\Character\Character;
 use Seat\Services\Repositories\Corporation\Corporation;
 use Seat\Web\Http\Controllers\Controller;
@@ -166,5 +167,15 @@ class SeatGroupsController extends Controller
         $changelog = $action->execute();
 
         return view('seatgroups::about', compact('changelog'));
+    }
+
+    public function dispatchUpdate()
+    {
+
+        Artisan::queue('seat-groups:users:update')->onQueue('high');
+
+        return redirect()->back()
+            ->with('success', 'SeAT Group update scheduled. Check back in a few moments');
+
     }
 }

--- a/src/Http/routes.php
+++ b/src/Http/routes.php
@@ -53,6 +53,10 @@ Route::group([
             'as'   => 'seatgroupuser.remove.manager',
             'uses' => 'SeatGroupUserController@removeManager',
         ]);
+        Route::get('/update', [
+            'as'   => 'seatgroup.user.update',
+            'uses' => 'SeatGroupsController@dispatchUpdate',
+        ]);
 
     });
 

--- a/src/Jobs/GroupDispatcher.php
+++ b/src/Jobs/GroupDispatcher.php
@@ -31,7 +31,7 @@ class GroupDispatcher extends SeatGroupsJobBase
             {
                $job = new GroupSync($users_group);
 
-               dispatch($job);
+               dispatch($job)->onQueue('high');
             });
 
         }, function ()

--- a/src/Jobs/GroupSync.php
+++ b/src/Jobs/GroupSync.php
@@ -157,7 +157,7 @@ class GroupSync extends SeatGroupsJobBase
                 ]);
 
                 // throw exception
-                throw new MissingRefreshTokenException();
+                $this->fail(new MissingRefreshTokenException($user));
             }
         }
     }
@@ -173,6 +173,8 @@ class GroupSync extends SeatGroupsJobBase
                 $this->main_character->name, $this->group->users->map(function ($user) { return $user->name; })->implode(', ')),
 
         ]);
+
+        $this->fail($exception);
 
     }
 

--- a/src/Jobs/GroupSync.php
+++ b/src/Jobs/GroupSync.php
@@ -44,6 +44,7 @@ class GroupSync extends SeatGroupsJobBase
      */
     public function __construct(Group $group)
     {
+
         $this->group = $group;
         $this->main_character = $group->main_character;
         if (is_null($group->main_character)) {
@@ -65,12 +66,13 @@ class GroupSync extends SeatGroupsJobBase
 
     public function handle()
     {
+
         // in case no main character has been set, throw an exception and abort the process
         if (is_null($this->main_character))
             throw new MissingMainCharacterException($this->group);
 
-        Redis::funnel('seat-groups:jobs.group_sync_' . $this->group->id)->limit(1)->then(function ()
-        {
+        Redis::funnel('seat-groups:jobs.group_sync_' . $this->group->id)->limit(1)->then(function () {
+
             $this->beforeStart();
 
             try {
@@ -95,7 +97,7 @@ class GroupSync extends SeatGroupsJobBase
                                 foreach ($seat_group->role as $role) {
                                     $roles->push($role->id);
                                 }
-                                if(! in_array($group->id, $seat_group->group->pluck('id')->toArray())){
+                                if (! in_array($group->id, $seat_group->group->pluck('id')->toArray())) {
                                     // add user_group to seat_group as member if no member yet.
                                     $seat_group->member()->attach($group->id);
                                 }
@@ -111,7 +113,7 @@ class GroupSync extends SeatGroupsJobBase
                                 }
                                 break;
                         }
-                    } elseif(in_array($group->id, $seat_group->group->pluck('id')->toArray())) {
+                    } elseif (in_array($group->id, $seat_group->group->pluck('id')->toArray())) {
                         $seat_group->member()->detach($group->id);
                     }
                 });
@@ -128,8 +130,8 @@ class GroupSync extends SeatGroupsJobBase
 
             }
 
-        }, function ()
-        {
+        }, function () {
+
             logger()->warning('A GroupSync job is already running for ' . $this->main_character->name . ' Removing the job from the queue.');
 
             $this->delete();
@@ -151,6 +153,7 @@ class GroupSync extends SeatGroupsJobBase
                 // take away all roles
                 $this->group->roles()->sync([]);
                 Seatgroup::all()->each(function ($seatgroup) {
+
                     $seatgroup->member()->detach($this->group->id);
                 });
 

--- a/src/Jobs/GroupSync.php
+++ b/src/Jobs/GroupSync.php
@@ -141,6 +141,10 @@ class GroupSync extends SeatGroupsJobBase
 
         foreach ($this->group->users as $user) {
 
+            //If user is deactivated skip the refresh_token check
+            if (! $user->active)
+                continue;
+
             // If a RefreshToken is missing
             if (is_null($user->refresh_token)) {
                 // take away all roles
@@ -160,6 +164,10 @@ class GroupSync extends SeatGroupsJobBase
                 $this->fail(new MissingRefreshTokenException($user));
             }
         }
+
+        // If deactivated user is alone in a group delete this job
+        if (! $this->group->users->first()->active && $this->group->users->count() === 1)
+            $this->delete();
     }
 
     public function onFail($exception)

--- a/src/Jobs/GroupSync.php
+++ b/src/Jobs/GroupSync.php
@@ -76,11 +76,14 @@ class GroupSync extends SeatGroupsJobBase
                 $roles = collect();
                 $group = $this->group;
 
-                //Catch Superuser
+                //Catch superuser permissions
                 foreach ($group->roles as $role) {
-                    if ($role->title === 'Superuser') {
-                        $roles->push($role->id);
+                    foreach ($role->permissions as $permission) {
+                        if ($permission->title === 'superuser') {
+                            $roles->push($role->id);
+                        }
                     }
+
                 }
 
                 Seatgroup::all()->each(function ($seat_group) use ($roles, $group) {

--- a/src/Jobs/GroupSync.php
+++ b/src/Jobs/GroupSync.php
@@ -161,7 +161,7 @@ class GroupSync extends SeatGroupsJobBase
                     'event'   => 'error',
                     'message' => sprintf('The RefreshToken of %s is missing, therefore user group of %s (%s) loses all permissions.' .
                         'Ask the owner of this user group to login again with this user, in order to provide a new RefreshToken. ',
-                        $user->name, $this->main_character->name, $this->group->users->map(function ($user) {return $user->name;})->implode(', ')),
+                        $user->name, $this->main_character->name, $this->group->users->map(function ($user) {return $user->name; })->implode(', ')),
                 ]);
 
                 // throw exception
@@ -182,7 +182,7 @@ class GroupSync extends SeatGroupsJobBase
         SeatgroupLog::create([
             'event'   => 'error',
             'message' => sprintf('An error occurred while syncing user group of %s (%s). Please check the logs.',
-                $this->main_character->name, $this->group->users->map(function ($user) {return $user->name;})->implode(', ')),
+                $this->main_character->name, $this->group->users->map(function ($user) {return $user->name; })->implode(', ')),
         ]);
 
         $this->fail($exception);

--- a/src/config/seatgroups.config.php
+++ b/src/config/seatgroups.config.php
@@ -6,7 +6,7 @@
  * Time: 10:24.
  */
 return [
-    'version'   => '1.4.2',
+    'version'   => '1.5.0',
 ];
 
 //TODO: Update Version

--- a/src/lang/en/seat.php
+++ b/src/lang/en/seat.php
@@ -52,4 +52,7 @@ return [
     'available_alliances' => 'Available Alliances',
     'add_alliance'        => 'Add Alliance',
 
+    //Event Log
+    'event' => 'Event',
+
 ];

--- a/src/resources/views/about.blade.php
+++ b/src/resources/views/about.blade.php
@@ -42,23 +42,40 @@
   </div>
 
   @if(auth()->user()->hasRole('seatgroups.create'))
-  <div class="box box-default">
-    <div class="box-header with-border">
-      <i class="fa fa-archive"></i>
+    <div class="box box-default">
+      <div class="box-header with-border">
+        <i class="fa fa-refresh"></i>
 
-      <h3 class="box-title">Last {{trans('seatgroups::seat.event')}} Log</h3>
+        <h3 class="box-title">{{ trans('web::seat.update') }} {{ trans('seatgroups::seat.seat_groups') }}</h3>
 
-      <span class="log-clear-button"></span>
 
+      </div>
+      <!-- /.box-header -->
+      <div class="box-body">
+        <a href="{{route('seatgroup.user.update')}}" class="btn btn-block btn-primary" role="button">{{ trans('seatgroups::seat.seat_groups') }} {{ trans_choice('web::seat.user',2) }} {{ trans('web::seat.update') }}</a>
+
+      </div>
+      <!-- /.box-body -->
     </div>
-    <!-- /.box-header -->
-    <div class="box-body">
+
+    <div class="box box-default">
+      <div class="box-header with-border">
+        <i class="fa fa-archive"></i>
+
+        <h3 class="box-title">Last {{trans('seatgroups::seat.event')}} Log</h3>
+
+        <span class="log-clear-button"></span>
+
+
+      </div>
+      <!-- /.box-header -->
+      <div class="box-body">
 
         @include('seatgroups::logs.list')
 
+      </div>
+      <!-- /.box-body -->
     </div>
-    <!-- /.box-body -->
-  </div>
   @endif
 
 @stop

--- a/src/resources/views/about.blade.php
+++ b/src/resources/views/about.blade.php
@@ -36,7 +36,7 @@
 
       <legend>Bugs and issues</legend>
 
-      <p>If you find something is not working as expectected, please don't hesitate and contact me. Either use SeAT-Slack or submit an <a href="https://github.com/herpaderpaldent/seat-groups/issues/new">issue on Github</a></p>
+      <p>If you find something is not working as expected, please don't hesitate and contact me. Either use SeAT-Slack or submit an <a href="https://github.com/herpaderpaldent/seat-groups/issues/new">issue on Github</a></p>
 
     </div>
   </div>
@@ -46,7 +46,7 @@
     <div class="box-header with-border">
       <i class="fa fa-archive"></i>
 
-      <h3 class="box-title">Last Event log</h3>
+      <h3 class="box-title">Last {{trans('seatgroups::seat.event')}} Log</h3>
 
       <span class="log-clear-button"></span>
 

--- a/src/resources/views/logs/list.blade.php
+++ b/src/resources/views/logs/list.blade.php
@@ -2,7 +2,7 @@
   <thead>
   <tr>
     <th>{{ trans('web::seat.date') }}</th>
-    <th>{{ trans('web::seat.category') }}</th>
+    <th>{{ trans('seatgroups::seat.event') }}</th>
     <th>{{ trans('web::seat.message') }}</th>
   </tr>
   </thead>

--- a/src/resources/views/logs/partials/event.blade.php
+++ b/src/resources/views/logs/partials/event.blade.php
@@ -1,10 +1,12 @@
 @switch($row->event)
-  @case('success')
+  @case('attached')
     <span class="label label-success"> {{$row->event}} </span>
     @break
-  @case('warning')
+  @case('detached')
     <span class="label label-warning"> {{$row->event}} </span>
     @break
   @case('error')
     <span class="label label-danger"> {{$row->event}} </span>
+  @default
+    <span class="label label-default"> {{$row->event}} </span>
 @endswitch

--- a/src/resources/views/partials/create-modal.blade.php
+++ b/src/resources/views/partials/create-modal.blade.php
@@ -67,17 +67,22 @@
 
   <script type="text/javascript">
 
-    $(document).ready(function(){
+    $(document).ready(function () {
       $("#SeATGroupCreate").on('show.bs.modal', function () {
         $("#available_roles").select2({
           placeholder: "{{ trans('web::seat.select_item_add') }}"
         });
         $.ajax({
-          type: 'GET',
-          url: '{{ route('seatgroups.create') }}',
-          success: function(data){
+          type   : 'GET',
+          url    : '{{ route('seatgroups.create') }}',
+          success: function (data) {
+
+            var select = $('#available_roles');
+
+            select.empty();
+
             for (var i = 0; i < data.length; i++) {
-              $('#available_roles').append($('<option></option>').attr('value', data[i].id).text(data[i].title));
+              select.append($('<option></option>').attr('value', data[i].id).text(data[i].title));
             }
           },
           error  : function (xhr, textStatus, errorThrown) {


### PR DESCRIPTION
# Version 1.5.0
Another major update on seat-groups. Containing many demanded features such as:
* Dispatching update job via web interface.
* Seat-Groups jobs are now dispatched on `high` queue (thanks @mmolitor87 for the suggestion).
* Clicking multiple times on `Add new SeAT Group` does not append multiple sets of roles anymore (thank you @MoucceuWildfire for reporting).
* SeAT-Groups now only logs attached and detached role events instead of every successful run (thank you @warlof for the idea).
* Deactivated users don't raise `MissingRefreshTokenExceptions` anymore
* `MissingRefreshTokenExceptions` are now more verbose.
 As you can see many of the implemented features are based from your valuable input. Please don't hesitate to contact me IG or via [slack](https://eveseat-slack.herokuapp.com/) (join plugin channel) with anything you'd like to discuss.