### PR TITLE
Version 1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Version 1.6.0
-This version is suited for the latet release of eveseat/web 3.0.10 and higher. SeAT now uses a newer version of datatables and therefore raw columns need to be enabled to show its html content.
+This version is suited for the latest release of eveseat/web 3.0.10 and higher. SeAT now uses a newer version of datatables and therefore raw columns need to be enabled to show its html content.
 
 # Version 1.5.2
 This is a minor usability update. All of the found improvements are based from @Eingang's Feedback. Whenever you find any issues please don't hesitate to open an issue.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Version 1.6.0
+This version is suited for the latet release of eveseat/web 3.0.10 and higher. SeAT now uses a newer version of datatables and therefore raw columns need to be enabled to show its html content.
+
 # Version 1.5.2
 This is a minor usability update. All of the found improvements are based from @Eingang's Feedback. Whenever you find any issues please don't hesitate to open an issue.
 * Empty corporation affiliation request caused an error. This update adds validation to form request

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Version 1.6.0
 This version is suited for the latest release of eveseat/web 3.0.10 and higher. SeAT now uses a newer version of datatables and therefore raw columns need to be enabled to show its html content.
+Also the dependency on form generator in edit blade was removed.
 
 # Version 1.5.2
 This is a minor usability update. All of the found improvements are based from @Eingang's Feedback. Whenever you find any issues please don't hesitate to open an issue.

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "require": {
         "php": ">=7.1",
         "laravel/framework": "5.5.*",
-        "eveseat/web": "~3"
+        "eveseat/web": ">=3.0.10"
     },
     "require-dev": {
         "orchestra/testbench": "3.5.*",

--- a/src/Http/Controllers/Affiliation/SeatGroupAffiliationController.php
+++ b/src/Http/Controllers/Affiliation/SeatGroupAffiliationController.php
@@ -11,7 +11,7 @@ namespace Herpaderpaldent\Seat\SeatGroups\Http\Controllers\Affiliation;
 use Herpaderpaldent\Seat\SeatGroups\Actions\SeatGroups\GetCurrentAffiliationAction;
 use Herpaderpaldent\Seat\SeatGroups\Http\Validation\Affiliation\GetCurrentAffiliationsRequest;
 use Illuminate\Routing\Controller;
-use Yajra\Datatables\Datatables;
+use Yajra\DataTables\DataTables;
 
 class SeatGroupAffiliationController extends Controller
 {
@@ -20,13 +20,14 @@ class SeatGroupAffiliationController extends Controller
 
         $affiliations = collect($action->execute($request->all()));
 
-        return Datatables::of($affiliations)
+        return DataTables::of($affiliations)
             ->addColumn('affiliation', function ($row) {
                 return view('seatgroups::affiliation.partials.table-partials.affiliation', compact('row'))->render();
             })
             ->addColumn('remove', function ($row) {
                 return view('seatgroups::affiliation.partials.table-partials.remove-button', compact('row'))->render();
             })
+            ->rawColumns(['affiliation', 'remove'])
             ->make(true);
 
     }

--- a/src/Http/Controllers/Logs/SeatGroupLogsController.php
+++ b/src/Http/Controllers/Logs/SeatGroupLogsController.php
@@ -10,7 +10,7 @@ namespace Herpaderpaldent\Seat\SeatGroups\Http\Controllers\Logs;
 
 use Herpaderpaldent\Seat\SeatGroups\Models\SeatgroupLog;
 use Seat\Web\Http\Controllers\Controller;
-use Yajra\Datatables\Datatables;
+use Yajra\DataTables\DataTables;
 
 class SeatGroupLogsController extends Controller
 {
@@ -26,13 +26,14 @@ class SeatGroupLogsController extends Controller
     {
         $logs = SeatgroupLog::query();
 
-        return Datatables::of($logs)
+        return DataTables::of($logs)
             ->editColumn('created_at', function ($row) {
                 return view('seatgroups::logs.partials.date', compact('row'));
             })
             ->editColumn('event', function ($row) {
                 return view('seatgroups::logs.partials.event', compact('row'));
             })
+            ->rawColumns(['created_at', 'event'])
             ->make(true);
 
     }

--- a/src/Http/Controllers/SeatGroupUserController.php
+++ b/src/Http/Controllers/SeatGroupUserController.php
@@ -11,7 +11,7 @@ use Herpaderpaldent\Seat\SeatGroups\Models\Seatgroup;
 use Illuminate\Http\Request;
 use Seat\Web\Acl\AccessManager;
 use Seat\Web\Http\Controllers\Controller;
-use Yajra\Datatables\Datatables;
+use Yajra\DataTables\DataTables;
 
 class SeatGroupUserController extends Controller
 {
@@ -226,13 +226,14 @@ class SeatGroupUserController extends Controller
     {
         $seatgroup_members = Seatgroup::find($id)->group;
 
-        return Datatables::of($seatgroup_members)
+        return DataTables::of($seatgroup_members)
             ->addColumn('name', function ($row) {
                 return view('seatgroups::partials.modal-partials.modal-name', compact('row'))->render();
             })
             ->addColumn('actions', function ($row) {
                 return view('seatgroups::partials.modal-partials.modal-actions', compact('row'))->render();
             })
+            ->rawColumns(['name', 'actions'])
             ->make(true);
     }
 }

--- a/src/Http/routes.php
+++ b/src/Http/routes.php
@@ -156,7 +156,7 @@ Route::group([
             'uses'       => 'SeatGroupsController@removeAffiliation',
         ]);
 
-        Route::delete('/{seat_group_id}/user/{group_id}', [
+        Route::post('/{seat_group_id}/user/{group_id}', [
             'as'         => 'seatgroupuser.removeGroupFromSeatGroup',
             'middleware' => 'bouncer:seatgroups.create',
             'uses'       => 'SeatGroupUserController@removeGroupFromSeatGroup',

--- a/src/config/seatgroups.config.php
+++ b/src/config/seatgroups.config.php
@@ -6,7 +6,7 @@
  * Time: 10:24.
  */
 return [
-    'version'   => '1.5.2',
+    'version'   => '1.6.0',
 ];
 
 //TODO: Update Version

--- a/src/resources/views/edit.blade.php
+++ b/src/resources/views/edit.blade.php
@@ -63,15 +63,12 @@
               <div class="col-md-12"></div>
               <div class="form-group col-md-12">
                 <label for="type">{{trans('seatgroups::seat.seat_groups_type')}}</label>
-                {{Form::select('type',[
-                    'auto' => 'auto',
-                    'managed'=>[
-                        'open'=>'open',
-                        'managed' => 'managed'
-                    ],
-                    'hidden' => 'hidden'
-                ], $seatgroup->type,['class'=>'form-control'])}}
-
+                <select class="form-control" name="type">
+                  <option value="auto" {{$seatgroup->type === 'auto' ? 'selected' : ''}}>auto</option>
+                  <option value="open" {{$seatgroup->type === 'open' ? 'selected' : ''}}>open</option>
+                  <option value="managed" {{$seatgroup->type === 'managed' ? 'selected' : ''}}>managed</option>
+                  <option value="hidden" {{$seatgroup->type === 'hidden' ? 'selected' : ''}}>hidden</option>
+                </select>
               </div>
             </div>
 
@@ -172,12 +169,13 @@
                     {{ $group->users->map(function($user) { return $user->name; })->implode(', ') }}
                   </td>
                   <td>
-                    {!! Form::open(['method' => 'DELETE',
-                'route' => ['seatgroupuser.removeGroupFromSeatGroup',$seatgroup->id,$group->id],
-                'style'=>'display:inline'
-                ]) !!}
-                    {!! Form::submit(trans('web::seat.remove'), ['class' => 'btn btn-danger btn-xs pull-right']) !!}
-                    {!! Form::close() !!}
+
+                    <form role="form" action="{{ route('seatgroupuser.removeGroupFromSeatGroup',['seat_group_id' => $seatgroup->id, 'group_id' => $group->id]) }}" method="post">
+                      {{ csrf_field() }}
+                      <button type="submit" class="btn btn-danger btn-xs pull-right">
+                        {{ trans('web::seat.remove') }}
+                      </button>
+                    </form>
                   </td>
                 </tr>
 

--- a/src/resources/views/partials/managed-group.blade.php
+++ b/src/resources/views/partials/managed-group.blade.php
@@ -15,7 +15,7 @@
 
     </div>
     <div class="box-footer">
-      Managers: {{$seatgroup->manager->map(function($user) { return $user->main_character->name; })->concat($seatgroup->children->map(function($children) { return $children->name; }))->implode(', ')}}
+      Managers: {{$seatgroup->manager->map(function($user) { return optional($user->main_character)->name; })->concat($seatgroup->children->map(function($children) { return $children->name; }))->implode(', ')}}
 
       @includeWhen($seatgroup->isManager(auth()->user()->group) || auth()->user()->hasSuperUser(),'seatgroups::partials.manager-modal')
 


### PR DESCRIPTION
# Version 1.6.0
This version is suited for the latest release of eveseat/web 3.0.10 and higher. SeAT now uses a newer version of datatables and therefore raw columns need to be enabled to show its html content.