### PR TITLE
Version 1.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+#Version 1.6.3
+This version attempts to resolve major outages in using seat-groups >1.6.0 if not used with seat-notifications installed.
+
+* Refactored GroupSync job to use events for missing refreshtoken, successful attaches/detached role updates and failed syncs
+* Events have two listeners: one for writing a log entry and one to dispatch a notification
+* `MissingRefreshTokenNotification` for discord contains a link to the configuration page of that user to quicker resolve false positive messages.
+
+log events are queued into the default queue whereas notifications are prioritized. Thank you @Lawin for pointing out this bug.
+
 # Version 1.6.2
 Refactoring some of the logic regarding permission checks. 
 

--- a/src/Events/GroupSyncFailed.php
+++ b/src/Events/GroupSyncFailed.php
@@ -3,11 +3,10 @@
  * Created by PhpStorm.
  * User: felix
  * Date: 08.01.2019
- * Time: 20:20
+ * Time: 20:20.
  */
 
 namespace Herpaderpaldent\Seat\SeatGroups\Events;
-
 
 use Illuminate\Queue\SerializesModels;
 use Seat\Eveapi\Models\Character\CharacterInfo;
@@ -28,5 +27,4 @@ class GroupSyncFailed
         $this->group = $group;
         $this->main_character = $main_character;
     }
-
 }

--- a/src/Events/GroupSyncFailed.php
+++ b/src/Events/GroupSyncFailed.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: felix
+ * Date: 08.01.2019
+ * Time: 20:20
+ */
+
+namespace Herpaderpaldent\Seat\SeatGroups\Events;
+
+
+use Illuminate\Queue\SerializesModels;
+use Seat\Eveapi\Models\Character\CharacterInfo;
+use Seat\Web\Models\Group;
+
+class GroupSyncFailed
+{
+    use SerializesModels;
+
+    public $group;
+
+    public $main_character;
+
+    public $sync;
+
+    public function __construct(Group $group, CharacterInfo $main_character)
+    {
+        $this->group = $group;
+        $this->main_character = $main_character;
+    }
+
+}

--- a/src/Events/GroupSynced.php
+++ b/src/Events/GroupSynced.php
@@ -3,11 +3,10 @@
  * Created by PhpStorm.
  * User: felix
  * Date: 08.01.2019
- * Time: 20:20
+ * Time: 20:20.
  */
 
 namespace Herpaderpaldent\Seat\SeatGroups\Events;
-
 
 use Illuminate\Queue\SerializesModels;
 use Seat\Eveapi\Models\Character\CharacterInfo;
@@ -29,5 +28,4 @@ class GroupSynced
         $this->main_character = $main_character;
         $this->sync = $sync;
     }
-
 }

--- a/src/Events/GroupSynced.php
+++ b/src/Events/GroupSynced.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: felix
+ * Date: 08.01.2019
+ * Time: 20:20
+ */
+
+namespace Herpaderpaldent\Seat\SeatGroups\Events;
+
+
+use Illuminate\Queue\SerializesModels;
+use Seat\Eveapi\Models\Character\CharacterInfo;
+use Seat\Web\Models\Group;
+
+class GroupSynced
+{
+    use SerializesModels;
+
+    public $group;
+
+    public $main_character;
+
+    public $sync;
+
+    public function __construct(Group $group, CharacterInfo $main_character, array $sync)
+    {
+        $this->group = $group;
+        $this->main_character = $main_character;
+        $this->sync = $sync;
+    }
+
+}

--- a/src/Events/MissingRefreshToken.php
+++ b/src/Events/MissingRefreshToken.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: felix
+ * Date: 08.01.2019
+ * Time: 22:40
+ */
+
+namespace Herpaderpaldent\Seat\SeatGroups\Events;
+
+
+use Illuminate\Queue\SerializesModels;
+use Seat\Eveapi\Models\Character\CharacterInfo;
+use Seat\Web\Models\User;
+
+class MissingRefreshToken
+{
+    use SerializesModels;
+
+    public $user;
+
+    public $main_character;
+
+    public function __construct(User $user, CharacterInfo $main_character)
+    {
+        $this->user = $user;
+        $this->main_character = $main_character;
+    }
+
+}

--- a/src/Events/MissingRefreshToken.php
+++ b/src/Events/MissingRefreshToken.php
@@ -3,11 +3,10 @@
  * Created by PhpStorm.
  * User: felix
  * Date: 08.01.2019
- * Time: 22:40
+ * Time: 22:40.
  */
 
 namespace Herpaderpaldent\Seat\SeatGroups\Events;
-
 
 use Illuminate\Queue\SerializesModels;
 use Seat\Eveapi\Models\Character\CharacterInfo;
@@ -26,5 +25,4 @@ class MissingRefreshToken
         $this->user = $user;
         $this->main_character = $main_character;
     }
-
 }

--- a/src/GroupsServiceProvider.php
+++ b/src/GroupsServiceProvider.php
@@ -4,10 +4,13 @@ namespace Herpaderpaldent\Seat\SeatGroups;
 
 use Herpaderpaldent\Seat\SeatGroups\Events\GroupSynced;
 use Herpaderpaldent\Seat\SeatGroups\Events\GroupSyncFailed;
+use Herpaderpaldent\Seat\SeatGroups\Events\MissingRefreshToken;
 use Herpaderpaldent\Seat\SeatGroups\Listeners\CreateSyncedSeatLogsEntry;
 use Herpaderpaldent\Seat\SeatGroups\Listeners\CreateSyncFailedLogsEntry;
 use Herpaderpaldent\Seat\SeatGroups\Listeners\GroupSyncedNotification;
 use Herpaderpaldent\Seat\SeatGroups\Listeners\GroupSyncFailedNotification;
+use Herpaderpaldent\Seat\SeatGroups\Listeners\MissingRefreshTokenLogsEntry;
+use Herpaderpaldent\Seat\SeatGroups\Listeners\MissingRefreshTokenNotification;
 use Herpaderpaldent\Seat\SeatGroups\Observers\RefreshTokenObserver;
 use Illuminate\Support\Arr;
 use Illuminate\Support\ServiceProvider;
@@ -87,6 +90,9 @@ class GroupsServiceProvider extends ServiceProvider
 
         $this->app->events->listen(GroupSyncFailed::class, CreateSyncFailedLogsEntry::class);
         $this->app->events->listen(GroupSyncFailed::class, GroupSyncFailedNotification::class);
+
+        $this->app->events->listen(MissingRefreshToken::class, MissingRefreshTokenLogsEntry::class);
+        $this->app->events->listen(MissingRefreshToken::class, MissingRefreshTokenNotification::class);
     }
 
     /**

--- a/src/GroupsServiceProvider.php
+++ b/src/GroupsServiceProvider.php
@@ -2,6 +2,12 @@
 
 namespace Herpaderpaldent\Seat\SeatGroups;
 
+use Herpaderpaldent\Seat\SeatGroups\Events\GroupSynced;
+use Herpaderpaldent\Seat\SeatGroups\Events\GroupSyncFailed;
+use Herpaderpaldent\Seat\SeatGroups\Listeners\CreateSyncedSeatLogsEntry;
+use Herpaderpaldent\Seat\SeatGroups\Listeners\CreateSyncFailedLogsEntry;
+use Herpaderpaldent\Seat\SeatGroups\Listeners\GroupSyncedNotification;
+use Herpaderpaldent\Seat\SeatGroups\Listeners\GroupSyncFailedNotification;
 use Herpaderpaldent\Seat\SeatGroups\Observers\RefreshTokenObserver;
 use Illuminate\Support\Arr;
 use Illuminate\Support\ServiceProvider;
@@ -24,6 +30,9 @@ class GroupsServiceProvider extends ServiceProvider
         $this->loadMigrationsFrom(__DIR__ . '/database/migrations/');
 
         RefreshToken::observe(RefreshTokenObserver::class);
+
+        $this->add_events();
+
     }
 
     /**
@@ -69,6 +78,15 @@ class GroupsServiceProvider extends ServiceProvider
     private function addTranslations()
     {
         $this->loadTranslationsFrom(__DIR__ . '/lang', 'seatgroups');
+    }
+
+    private function add_events()
+    {
+        $this->app->events->listen(GroupSynced::class, CreateSyncedSeatLogsEntry::class);
+        $this->app->events->listen(GroupSynced::class, GroupSyncedNotification::class);
+
+        $this->app->events->listen(GroupSyncFailed::class, CreateSyncFailedLogsEntry::class);
+        $this->app->events->listen(GroupSyncFailed::class, GroupSyncFailedNotification::class);
     }
 
     /**

--- a/src/Jobs/GroupSync.php
+++ b/src/Jobs/GroupSync.php
@@ -12,13 +12,7 @@ use Herpaderpaldent\Seat\SeatGroups\Events\GroupSynced;
 use Herpaderpaldent\Seat\SeatGroups\Events\GroupSyncFailed;
 use Herpaderpaldent\Seat\SeatGroups\Events\MissingRefreshToken;
 use Herpaderpaldent\Seat\SeatGroups\Models\Seatgroup;
-use Herpaderpaldent\Seat\SeatGroups\Models\SeatgroupLog;
-use Herpaderpaldent\Seat\SeatGroups\Models\SeatGroupNotification;
-use Herpaderpaldent\Seat\SeatGroups\Notifications\SeatGroupErrorNotification;
-use Herpaderpaldent\Seat\SeatGroups\Notifications\SeatGroupUpdateNotification;
-use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\Facades\Redis;
-use Seat\Web\Models\Acl\Role;
 use Seat\Web\Models\Group;
 use Seat\Web\Models\User;
 

--- a/src/Listeners/CreateSyncFailedLogsEntry.php
+++ b/src/Listeners/CreateSyncFailedLogsEntry.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: felix
+ * Date: 08.01.2019
+ * Time: 22:23
+ */
+
+namespace Herpaderpaldent\Seat\SeatGroups\Listeners;
+
+
+use Herpaderpaldent\Seat\SeatGroups\Events\GroupSyncFailed;
+use Herpaderpaldent\Seat\SeatGroups\Models\SeatgroupLog;
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+class CreateSyncFailedLogsEntry implements ShouldQueue
+{
+    public function __construct()
+    {
+        //
+    }
+
+    public function handle(GroupSyncFailed $event)
+    {
+
+        $message = sprintf('An error occurred while syncing user group of %s (%s). Please check the logs.',
+            $event->main_character->name,
+            $event->group->users->map(function ($user) {return $user->name; })->implode(', ')
+        );
+
+        SeatgroupLog::create([
+            'event'   => 'error',
+            'message' => $message,
+        ]);
+
+    }
+
+}

--- a/src/Listeners/CreateSyncFailedLogsEntry.php
+++ b/src/Listeners/CreateSyncFailedLogsEntry.php
@@ -3,11 +3,10 @@
  * Created by PhpStorm.
  * User: felix
  * Date: 08.01.2019
- * Time: 22:23
+ * Time: 22:23.
  */
 
 namespace Herpaderpaldent\Seat\SeatGroups\Listeners;
-
 
 use Herpaderpaldent\Seat\SeatGroups\Events\GroupSyncFailed;
 use Herpaderpaldent\Seat\SeatGroups\Models\SeatgroupLog;
@@ -17,7 +16,7 @@ class CreateSyncFailedLogsEntry implements ShouldQueue
 {
     public function __construct()
     {
-        //
+
     }
 
     public function handle(GroupSyncFailed $event)
@@ -34,5 +33,4 @@ class CreateSyncFailedLogsEntry implements ShouldQueue
         ]);
 
     }
-
 }

--- a/src/Listeners/CreateSyncedSeatLogsEntry.php
+++ b/src/Listeners/CreateSyncedSeatLogsEntry.php
@@ -3,11 +3,10 @@
  * Created by PhpStorm.
  * User: felix
  * Date: 08.01.2019
- * Time: 20:28
+ * Time: 20:28.
  */
 
 namespace Herpaderpaldent\Seat\SeatGroups\Listeners;
-
 
 use Herpaderpaldent\Seat\SeatGroups\Events\GroupSynced;
 use Herpaderpaldent\Seat\SeatGroups\Models\SeatgroupLog;
@@ -21,12 +20,12 @@ class CreateSyncedSeatLogsEntry implements ShouldQueue
 
     public function __construct()
     {
-        //
+
     }
 
     public function handle(GroupSynced $event)
     {
-        if ( empty($event->sync['attached']) && empty($event->sync['detached']))
+        if (empty($event->sync['attached']) && empty($event->sync['detached']))
             $this->delete();
 
         if (! empty($event->sync['attached'])) {
@@ -73,5 +72,4 @@ class CreateSyncedSeatLogsEntry implements ShouldQueue
     {
         report($exception);
     }
-
 }

--- a/src/Listeners/CreateSyncedSeatLogsEntry.php
+++ b/src/Listeners/CreateSyncedSeatLogsEntry.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: felix
+ * Date: 08.01.2019
+ * Time: 20:28
+ */
+
+namespace Herpaderpaldent\Seat\SeatGroups\Listeners;
+
+
+use Herpaderpaldent\Seat\SeatGroups\Events\GroupSynced;
+use Herpaderpaldent\Seat\SeatGroups\Models\SeatgroupLog;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Queue\InteractsWithQueue;
+use Seat\Web\Models\Acl\Role;
+
+class CreateSyncedSeatLogsEntry implements ShouldQueue
+{
+    use InteractsWithQueue;
+
+    public function __construct()
+    {
+        //
+    }
+
+    public function handle(GroupSynced $event)
+    {
+        if ( empty($event->sync['attached']) && empty($event->sync['detached']))
+            $this->delete();
+
+        if (! empty($event->sync['attached'])) {
+
+            SeatgroupLog::create([
+                'event'   => 'attached',
+                'message' => sprintf('The user group of %s (%s) has successfully been attached to the following roles: %s.',
+                    $event->main_character->name,
+                    $event->group->users->map(function ($user) {
+
+                        return $user->name;
+                    })->implode(', '),
+                    Role::whereIn('id', $event->sync['attached'])->pluck('title')->implode(', ')
+                ),
+            ]);
+        }
+
+        if (! empty($event->sync['detached'])) {
+
+            SeatgroupLog::create([
+                'event'   => 'detached',
+                'message' => sprintf('The user group of %s (%s) has been detached from the following roles: %s.',
+                    $event->main_character->name,
+                    $event->group->users->map(function ($user) {
+
+                        return $user->name;
+                    })->implode(', '),
+                    Role::whereIn('id', $event->sync['detached'])->pluck('title')->implode(', ')
+                ),
+            ]);
+        }
+
+    }
+
+    /**
+     * Handle a job failure.
+     *
+     * @param \Herpaderpaldent\Seat\SeatGroups\Events\GroupSynced $event
+     * @param  \Exception                                         $exception
+     *
+     * @return void
+     */
+    public function failed(GroupSynced $event, $exception)
+    {
+        report($exception);
+    }
+
+}

--- a/src/Listeners/GroupSyncFailedNotification.php
+++ b/src/Listeners/GroupSyncFailedNotification.php
@@ -3,11 +3,10 @@
  * Created by PhpStorm.
  * User: felix
  * Date: 08.01.2019
- * Time: 20:38
+ * Time: 20:38.
  */
 
 namespace Herpaderpaldent\Seat\SeatGroups\Listeners;
-
 
 use Herpaderpaldent\Seat\SeatGroups\Events\GroupSyncFailed;
 use Herpaderpaldent\Seat\SeatGroups\Models\SeatGroupNotification;
@@ -20,7 +19,7 @@ class GroupSyncFailedNotification
 {
     public function __construct()
     {
-        //
+
     }
 
     public function handle(GroupSyncFailed $event)
@@ -41,5 +40,4 @@ class GroupSyncFailedNotification
             Notification::send($recipients, (new SeatGroupErrorNotification(User::find($event->main_character->character_id), $message)));
         }
     }
-
 }

--- a/src/Listeners/GroupSyncFailedNotification.php
+++ b/src/Listeners/GroupSyncFailedNotification.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: felix
+ * Date: 08.01.2019
+ * Time: 20:38
+ */
+
+namespace Herpaderpaldent\Seat\SeatGroups\Listeners;
+
+
+use Herpaderpaldent\Seat\SeatGroups\Events\GroupSyncFailed;
+use Herpaderpaldent\Seat\SeatGroups\Models\SeatGroupNotification;
+use Herpaderpaldent\Seat\SeatGroups\Notifications\SeatGroupErrorNotification;
+use Herpaderpaldent\Seat\SeatNotifications\Notifications\BaseNotification;
+use Illuminate\Support\Facades\Notification;
+use Seat\Web\Models\User;
+
+class GroupSyncFailedNotification
+{
+    public function __construct()
+    {
+        //
+    }
+
+    public function handle(GroupSyncFailed $event)
+    {
+        $should_send = false;
+
+        if (class_exists(BaseNotification::class))
+            $should_send = true;
+
+        if ($should_send){
+
+            $recipients = SeatGroupNotification::all();
+            $message = sprintf('An error occurred while syncing user group of %s (%s). Please check the logs.',
+                $event->main_character->name,
+                $event->group->users->map(function ($user) {return $user->name; })->implode(', ')
+            );
+
+            Notification::send($recipients, (new SeatGroupErrorNotification(User::find($event->main_character->character_id), $message)));
+        }
+    }
+
+}

--- a/src/Listeners/GroupSyncedNotification.php
+++ b/src/Listeners/GroupSyncedNotification.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: felix
+ * Date: 08.01.2019
+ * Time: 20:38
+ */
+
+namespace Herpaderpaldent\Seat\SeatGroups\Listeners;
+
+
+use Herpaderpaldent\Seat\SeatGroups\Events\GroupSynced;
+use Herpaderpaldent\Seat\SeatGroups\Models\SeatGroupNotification;
+use Herpaderpaldent\Seat\SeatGroups\Notifications\SeatGroupUpdateNotification;
+use Herpaderpaldent\Seat\SeatNotifications\Notifications\BaseNotification;
+use Illuminate\Support\Facades\Notification;
+
+class GroupSyncedNotification
+{
+    public function __construct()
+    {
+        //
+    }
+
+    public function handle(GroupSynced $event)
+    {
+        $should_send = false;
+
+        if (! empty($event->sync['attached']))
+            $should_send = true;
+
+        if (! empty($event->sync['detached']))
+            $should_send = true;
+
+        if (! class_exists(BaseNotification::class))
+            $should_send = false;
+
+        if ($should_send){
+
+            $recipients = SeatGroupNotification::all();
+
+            Notification::send($recipients, (new SeatGroupUpdateNotification($event->group, $event->sync)));
+        }
+    }
+
+}

--- a/src/Listeners/GroupSyncedNotification.php
+++ b/src/Listeners/GroupSyncedNotification.php
@@ -3,11 +3,10 @@
  * Created by PhpStorm.
  * User: felix
  * Date: 08.01.2019
- * Time: 20:38
+ * Time: 20:38.
  */
 
 namespace Herpaderpaldent\Seat\SeatGroups\Listeners;
-
 
 use Herpaderpaldent\Seat\SeatGroups\Events\GroupSynced;
 use Herpaderpaldent\Seat\SeatGroups\Models\SeatGroupNotification;
@@ -19,7 +18,7 @@ class GroupSyncedNotification
 {
     public function __construct()
     {
-        //
+
     }
 
     public function handle(GroupSynced $event)
@@ -42,5 +41,4 @@ class GroupSyncedNotification
             Notification::send($recipients, (new SeatGroupUpdateNotification($event->group, $event->sync)));
         }
     }
-
 }

--- a/src/Listeners/MissingRefreshTokenLogsEntry.php
+++ b/src/Listeners/MissingRefreshTokenLogsEntry.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: felix
+ * Date: 09.01.2019
+ * Time: 19:12
+ */
+
+namespace Herpaderpaldent\Seat\SeatGroups\Listeners;
+
+
+use Herpaderpaldent\Seat\SeatGroups\Events\MissingRefreshToken;
+use Herpaderpaldent\Seat\SeatGroups\Models\SeatgroupLog;
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+class MissingRefreshTokenLogsEntry implements ShouldQueue
+{
+    public function __construct()
+    {
+        //
+    }
+
+    public function handle(MissingRefreshToken $event)
+    {
+
+        $message = sprintf('The RefreshToken of %s in user group of %s (%s) is missing. '
+            . 'Ask the owner of this user group to login again with this user, in order to provide a new RefreshToken. '
+            . 'This user group will lose all potentially gained roles through this character.',
+            $event->user->name, $event->main_character->name, $event->user->group->users->map(function ($user) {return $user->name; })
+                ->implode(', ')
+        );
+
+        SeatgroupLog::create([
+            'event'   => 'error',
+            'message' => $message,
+        ]);
+
+    }
+
+}

--- a/src/Listeners/MissingRefreshTokenLogsEntry.php
+++ b/src/Listeners/MissingRefreshTokenLogsEntry.php
@@ -3,11 +3,10 @@
  * Created by PhpStorm.
  * User: felix
  * Date: 09.01.2019
- * Time: 19:12
+ * Time: 19:12.
  */
 
 namespace Herpaderpaldent\Seat\SeatGroups\Listeners;
-
 
 use Herpaderpaldent\Seat\SeatGroups\Events\MissingRefreshToken;
 use Herpaderpaldent\Seat\SeatGroups\Models\SeatgroupLog;
@@ -17,7 +16,7 @@ class MissingRefreshTokenLogsEntry implements ShouldQueue
 {
     public function __construct()
     {
-        //
+
     }
 
     public function handle(MissingRefreshToken $event)
@@ -36,5 +35,4 @@ class MissingRefreshTokenLogsEntry implements ShouldQueue
         ]);
 
     }
-
 }

--- a/src/Listeners/MissingRefreshTokenNotification.php
+++ b/src/Listeners/MissingRefreshTokenNotification.php
@@ -3,23 +3,22 @@
  * Created by PhpStorm.
  * User: felix
  * Date: 09.01.2019
- * Time: 19:23
+ * Time: 19:23.
  */
 
 namespace Herpaderpaldent\Seat\SeatGroups\Listeners;
 
-
 use Herpaderpaldent\Seat\SeatGroups\Events\MissingRefreshToken;
 use Herpaderpaldent\Seat\SeatGroups\Models\SeatGroupNotification;
+use Herpaderpaldent\Seat\SeatGroups\Notifications\MissingRefreshTokenNotification as RefreshTokenNotification;
 use Herpaderpaldent\Seat\SeatNotifications\Notifications\BaseNotification;
 use Illuminate\Support\Facades\Notification;
-use Herpaderpaldent\Seat\SeatGroups\Notifications\MissingRefreshTokenNotification as RefreshTokenNotification;
 
 class MissingRefreshTokenNotification
 {
     public function __construct()
     {
-        //
+
     }
 
     public function handle(MissingRefreshToken $event)
@@ -37,5 +36,4 @@ class MissingRefreshTokenNotification
             Notification::send($recipients, (new RefreshTokenNotification($event->user)));
         }
     }
-
 }

--- a/src/Listeners/MissingRefreshTokenNotification.php
+++ b/src/Listeners/MissingRefreshTokenNotification.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: felix
+ * Date: 09.01.2019
+ * Time: 19:23
+ */
+
+namespace Herpaderpaldent\Seat\SeatGroups\Listeners;
+
+
+use Herpaderpaldent\Seat\SeatGroups\Events\MissingRefreshToken;
+use Herpaderpaldent\Seat\SeatGroups\Models\SeatGroupNotification;
+use Herpaderpaldent\Seat\SeatNotifications\Notifications\BaseNotification;
+use Illuminate\Support\Facades\Notification;
+use Herpaderpaldent\Seat\SeatGroups\Notifications\MissingRefreshTokenNotification as RefreshTokenNotification;
+
+class MissingRefreshTokenNotification
+{
+    public function __construct()
+    {
+        //
+    }
+
+    public function handle(MissingRefreshToken $event)
+    {
+        $should_send = false;
+        logger()->debug('notificationListener');
+
+        if (class_exists(BaseNotification::class))
+            $should_send = true;
+
+        if ($should_send){
+
+            $recipients = SeatGroupNotification::all();
+
+            Notification::send($recipients, (new RefreshTokenNotification($event->user)));
+        }
+    }
+
+}

--- a/src/Notifications/MissingRefreshTokenNotification.php
+++ b/src/Notifications/MissingRefreshTokenNotification.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * Created by PhpStorm.
+ *  * User: Herpaderp Aldent
+ * Date: 05.07.2018
+ * Time: 15:53.
+ */
+
+namespace Herpaderpaldent\Seat\SeatGroups\Notifications;
+
+use Herpaderpaldent\Seat\SeatNotifications\Channels\Discord\DiscordChannel;
+use Herpaderpaldent\Seat\SeatNotifications\Channels\Discord\DiscordMessage;
+use Herpaderpaldent\Seat\SeatNotifications\Channels\Slack\SlackChannel;
+use Herpaderpaldent\Seat\SeatNotifications\Channels\Slack\SlackMessage;
+use Herpaderpaldent\Seat\SeatNotifications\Notifications\BaseNotification;
+use Seat\Web\Models\User;
+
+class MissingRefreshTokenNotification extends BaseNotification
+{
+    /**
+     * @var array
+     */
+    protected $tags = ['seat_group', 'missing_refresh_token'];
+
+    protected $image;
+
+    /**
+     * @var \Seat\Web\Models\User
+     */
+    protected $user;
+
+    protected $url;
+
+    protected $main_character;
+
+    protected $group;
+
+    public function __construct(User $user)
+    {
+        parent::__construct();
+
+        $this->user = $user;
+        $this->image = 'https://imageserver.eveonline.com/Character/' . $user->id . '_128.jpg';
+        $this->url = route('configuration.users.edit', ['user_id' => $user->id]);
+        $this->main_character = $this->getMainCharacter($user->group)->name;
+        $this->group = $user->group;
+    }
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @param  mixed  $notifiable
+     * @return array
+     */
+    public function via($notifiable)
+    {
+
+        switch($notifiable->via) {
+            case 'discord':
+                $this->tags = array_merge($this->tags, [
+                    'discord',
+                ]);
+
+                return [DiscordChannel::class];
+                break;
+            case 'slack':
+                $this->tags = array_merge($this->tags, [
+                    'slack',
+                ]);
+
+                return [SlackChannel::class];
+                break;
+            default:
+                return [''];
+        }
+    }
+
+    public function toDiscord($notifiable)
+    {
+        $message = sprintf('The RefreshToken of [%s](%s) is missing. '
+            . 'Ask the owner of this user group to login again with this user, in order to provide a new RefreshToken. '
+            . 'This user group will lose all potentially gained roles through this character.',
+            $this->user->name,
+            $this->url
+        );
+
+        return (new DiscordMessage)
+            ->embed(function ($embed) use ($message){
+
+                $embed->title('** Error **')
+                    ->thumbnail($this->image)
+                    ->color('12727073')
+                    ->field('Missing Refresh Token', $message, false)
+                    ->field('Main character', $this->main_character, true)
+                    ->field('User group', $this->group->users->map(function ($user) {return $user->name; })->implode(', '), true);
+            });
+    }
+
+    /**
+     * @param $notifiable
+     *
+     * @return \Herpaderpaldent\Seat\SeatNotifications\Channels\Slack\SlackMessage
+     */
+    public function toSlack($notifiable)
+    {
+        $message = sprintf('The RefreshToken of %s in user group of %s (%s) is missing. '
+            . 'Ask the owner of this user group to login again with this user, in order to provide a new RefreshToken. '
+            . 'This user group will lose all potentially gained roles through this character.',
+            $this->user->name,
+            $this->main_character,
+            $this->group->users->map(function ($user) {return $user->name; })
+            ->implode(', ')
+        );
+
+        return (new SlackMessage)
+            ->warning()
+            ->attachment(function ($attachment) use ($message) {
+                $attachment
+                    ->title('Error', $this->url)
+                    ->thumb($this->image)
+                    ->color('C23321')
+                    ->content($message);
+            });
+    }
+}

--- a/src/Notifications/MissingRefreshTokenNotification.php
+++ b/src/Notifications/MissingRefreshTokenNotification.php
@@ -85,7 +85,7 @@ class MissingRefreshTokenNotification extends BaseNotification
         );
 
         return (new DiscordMessage)
-            ->embed(function ($embed) use ($message){
+            ->embed(function ($embed) use ($message) {
 
                 $embed->title('** Error **')
                     ->thumbnail($this->image)

--- a/src/config/seatgroups.config.php
+++ b/src/config/seatgroups.config.php
@@ -6,7 +6,7 @@
  * Time: 10:24.
  */
 return [
-    'version'   => '1.6.2',
+    'version'   => '1.6.3',
 ];
 
 //TODO: Update Version


### PR DESCRIPTION
This version attempts to resolve major outages in using seat-groups >1.6.0 if not used with seat-notifications installed.

* Refactored GroupSync job to use events for missing refreshtoken, successful attaches/detached role updates and failed syncs
* Events have two listeners: one for writing a log entry and one to dispatch a notification
* `MissingRefreshTokenNotification` for discord contains a link to the configuration page of that user to quicker resolve false positive messages.

log events are queued into the default queue whereas notifications are prioritized. Thank you @Lawin for pointing out this bug.