### PR TITLE
Version 1.6.7 - cleanup of deleted models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# Version 1.6.7
+This version replaces `SeATGroupNotification` models in:
+* `GroupSyncFailedNotification` listener
+* `MissingRefreshTokenNotification` listener
+with correct `SeatNotificationRecipient` model.
+
+Sorry about that and thank you @GoemFunaila for reporting this issue.
+
 # Version 1.6.6
 Small fix to select correct notification channel
 

--- a/src/Listeners/GroupSyncFailedNotification.php
+++ b/src/Listeners/GroupSyncFailedNotification.php
@@ -1,5 +1,29 @@
 <?php
 /**
+ * MIT License.
+ *
+ * Copyright (c) 2019. Felix Huber
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
  * Created by PhpStorm.
  * User: felix
  * Date: 08.01.2019
@@ -9,8 +33,8 @@
 namespace Herpaderpaldent\Seat\SeatGroups\Listeners;
 
 use Herpaderpaldent\Seat\SeatGroups\Events\GroupSyncFailed;
-use Herpaderpaldent\Seat\SeatGroups\Models\SeatGroupNotification;
 use Herpaderpaldent\Seat\SeatGroups\Notifications\SeatGroupErrorNotification;
+use Herpaderpaldent\Seat\SeatNotifications\Models\SeatNotificationRecipient;
 use Herpaderpaldent\Seat\SeatNotifications\Notifications\BaseNotification;
 use Illuminate\Support\Facades\Notification;
 use Seat\Web\Models\User;
@@ -31,7 +55,7 @@ class GroupSyncFailedNotification
 
         if ($should_send){
 
-            $recipients = SeatGroupNotification::all()
+            $recipients = SeatNotificationRecipient::all()
                 ->filter(function ($recipient) {
                     return $recipient->shouldReceive('seatgroup_error');
                 });

--- a/src/Listeners/MissingRefreshTokenNotification.php
+++ b/src/Listeners/MissingRefreshTokenNotification.php
@@ -1,5 +1,29 @@
 <?php
 /**
+ * MIT License.
+ *
+ * Copyright (c) 2019. Felix Huber
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
  * Created by PhpStorm.
  * User: felix
  * Date: 09.01.2019
@@ -9,8 +33,8 @@
 namespace Herpaderpaldent\Seat\SeatGroups\Listeners;
 
 use Herpaderpaldent\Seat\SeatGroups\Events\MissingRefreshToken;
-use Herpaderpaldent\Seat\SeatGroups\Models\SeatGroupNotification;
 use Herpaderpaldent\Seat\SeatGroups\Notifications\MissingRefreshTokenNotification as RefreshTokenNotification;
+use Herpaderpaldent\Seat\SeatNotifications\Models\SeatNotificationRecipient;
 use Herpaderpaldent\Seat\SeatNotifications\Notifications\BaseNotification;
 use Illuminate\Support\Facades\Notification;
 
@@ -31,7 +55,7 @@ class MissingRefreshTokenNotification
 
         if ($should_send){
 
-            $recipients = SeatGroupNotification::all()
+            $recipients = SeatNotificationRecipient::all()
                 ->filter(function ($recipient) {
                     return $recipient->shouldReceive('missing_refreshtoken');
                 });

--- a/src/config/seatgroups.config.php
+++ b/src/config/seatgroups.config.php
@@ -24,7 +24,7 @@
  */
 
 return [
-    'version'   => '1.6.6',
+    'version'   => '1.6.7',
 ];
 
 //TODO: Update Version


### PR DESCRIPTION
This version replaces `SeATGroupNotification` models in:
* `GroupSyncFailedNotification` listener
* `MissingRefreshTokenNotification` listener
with correct `SeatNotificationRecipient` model.

Sorry about that and thank you @GoemFunaila for reporting this issue.

Closes: https://github.com/herpaderpaldent/seat-groups/issues/73